### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install tweepy"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 
 making a bot for [Git Commit Show](https://www.gitcommit.show)
+
+[![Run on Repl.it](https://repl.it/badge/github/thenerdsuperuser/gitcommitshow)](https://repl.it/github/thenerdsuperuser/gitcommitshow)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).